### PR TITLE
Fix issue #3

### DIFF
--- a/lib/api-ai-ruby/request_query.rb
+++ b/lib/api-ai-ruby/request_query.rb
@@ -17,7 +17,7 @@ module ApiAiRuby
       options[:lang] = client.api_lang
       @options = options
       @headers = {
-          'Authorization': 'Bearer ' + client.client_access_token,
+          Authorization: 'Bearer ' + client.client_access_token,
       }
     end
 


### PR DESCRIPTION
#### Background
The form of Hash `{'key': 'value'}` is not supported by **Ruby 2.1.6** and down

#### What this PR does
Change the ussage in **request_query.rb:20** to `Authorization: 'Bearer ' + client.client_access_token,`

#### Link to Issue
Fixes https://github.com/api-ai/api-ai-ruby/issues/3