### PR TITLE
Upgrade to http 2.0

### DIFF
--- a/api-ai-ruby.gemspec
+++ b/api-ai-ruby.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_dependency 'http', '~> 0.9.4'
+  spec.add_dependency 'http', '~> 2.0'
 
 end

--- a/lib/api-ai-ruby/request/request_query.rb
+++ b/lib/api-ai-ruby/request/request_query.rb
@@ -29,7 +29,7 @@ module ApiAiRuby
         options_key = (@request_method === :get) ? :params : :json
       end
 
-      request = HTTP.with(@headers)
+      request = HTTP.headers(@headers)
       request = request.timeout(*@timeout_options) if @timeout_options
       response = request.public_send(@request_method, @uri.to_s, options_key => @options) if @options
       response = request.public_send(@request_method, @uri.to_s) if @options == nil

--- a/spec/api-ai-ruby/text_request_spec.rb
+++ b/spec/api-ai-ruby/text_request_spec.rb
@@ -51,7 +51,7 @@ describe ApiAiRuby::TextRequest do
                :headers => expected_headers).to_timeout
         expect {
           subject.perform
-        }.to raise_error(Errno::ETIMEDOUT)
+        }.to raise_error(HTTP::ConnectionError)
         expect(stub).to have_been_requested
       end
     end


### PR DESCRIPTION
The current used http version is quite old, it would be probably a good idea to uprgade it.
We are currently getting conflicts with twitter gem:

```
Resolving dependencies................................
Bundler could not find compatible versions for gem "http":
  In Gemfile:
    api-ai-ruby (~> 1.2) was resolved to 1.2.0, which depends on
      http (~> 0.9.4)

    twitter was resolved to 5.15.0, which depends on
      http (~> 2.0)
```

Note that http gem does no longer raise `Errno::ETIMEDOUT` and this will be a backwards incompat also for this gems users as it didn't rescue and threw a gem specific error. Therefore I think when merging this change api-ai-ruby needs a major version bump.
